### PR TITLE
Update hemingway to 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ TODO.md
 tmp/
 logs/
 .mise
+.hemingway/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,9 +17,9 @@ GIT
 
 GIT
   remote: https://github.com/calef/hemingway.git
-  revision: ff9fd4e35dbfdc2be71918114a314ca9a6185002
+  revision: 3488fb9cc60b03002e3f85ab61825adf3075bc90
   specs:
-    hemingway (0.2.5)
+    hemingway (0.3.0)
       base64
       chio
       fmrepo

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,9 +17,9 @@ GIT
 
 GIT
   remote: https://github.com/calef/hemingway.git
-  revision: 3488fb9cc60b03002e3f85ab61825adf3075bc90
+  revision: 68737c9f3b7370687ea8eb033858b47166cc3f17
   specs:
-    hemingway (0.3.0)
+    hemingway (0.3.1)
       base64
       chio
       fmrepo


### PR DESCRIPTION
## Summary
- Update hemingway from 0.2.5 to 0.3.0 (background publish, enhanced status)
- Add `.hemingway/` to `.gitignore` for PID/log/stage files

## Test plan
- [x] `bundle update hemingway` resolves cleanly
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)